### PR TITLE
Improved speed of 'transfer_history()' by reducing number of calls to 'get_card()'

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -407,15 +407,15 @@ def testFunction() -> None:
 
 def transfer_history(source, target):
     counter = 0
-    for x in source:
-        card_to_update = mw.col.get_card(x)
+    source_cards = [mw.col.get_card(card_id) for card_id in source]
+    target_cards = [mw.col.get_card(card_id) for card_id in target]
+    for card_to_update in source_cards:
         note_to_update = card_to_update.note()
 
         word = str(note_to_update["Word"])
         word_reading = str(note_to_update["Word Reading"])
 
-        for y in target:
-            c = mw.col.get_card(y)
+        for c in target_cards:
             n = c.note()
 
             c_word = str(n["Word"])


### PR DESCRIPTION
By moving the calls to `get_card()` from inside a double for loop to instead reside in two line-comprehensions, the number of times we call `get_card()` decreases, and the speed of the "Review History to Kaishi 1.5k" action increases. The time complexity decreases from O(n*m) to O(n+m). This was the main bottleneck of this action in terms of speed.